### PR TITLE
Moved the margin to where it belongs

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.module.sass
+++ b/src/components/breadcrumbs/breadcrumbs.module.sass
@@ -1,6 +1,6 @@
 .breadcrumbs
   list-style: none
-  margin: 0
+  margin: 0 20px 0 0
 
 .breadcrumb_item
   color: #606060

--- a/src/components/time_to_prepare/time_to_prepare.module.sass
+++ b/src/components/time_to_prepare/time_to_prepare.module.sass
@@ -3,7 +3,6 @@
 .time_box
   display: flex
   align-items: baseline
-  margin-left: 20px
 
   +media('<phone_l')
     font-size: 14px


### PR DESCRIPTION
Having the margin on the time_box directly changed it also on the homepage  which was definitely not desirable.