### PR TITLE
Fix first paint

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,7 +3,7 @@ const Layout = require('./src/components/layout').default
 const { renderToString } = require('react-dom/server')
 const { renderStylesToString } = require('emotion-server')
 
-exports.replaceRenderer = function ({ bodyComponent, replaceBodyHTMLString}) {
+exports.replaceRenderer = function ({bodyComponent, replaceBodyHTMLString}) {
   const html = renderStylesToString(renderToString(bodyComponent))
   replaceBodyHTMLString(html)
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "emotion": "^10.0.7",
-    "emotion-server": "^10.0.7",
+    "emotion": "9",
+    "emotion-server": "9",
     "fuse.js": "^3.3.0",
     "gatsby": "^2.3.29",
     "gatsby-image": "^2.0.25",

--- a/src/components/layout/layout.sass
+++ b/src/components/layout/layout.sass
@@ -2,3 +2,10 @@
 
 html, body
   background-color: $grey1
+
+#gatsby-noscript
+  display: block
+  margin: 0
+  padding: 10px
+  background-color: #333
+  color: #e98500

--- a/yarn.lock
+++ b/yarn.lock
@@ -3979,23 +3979,13 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-emotion-server@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/create-emotion-server/-/create-emotion-server-10.0.0.tgz#d7089cbff60f6ba8776601b9a6d22ab39e260633"
+create-emotion-server@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion-server/-/create-emotion-server-9.2.12.tgz#30d82507bfe440bfb3dd6c9b5c8faf24597ee954"
   dependencies:
-    "@emotion/utils" "0.11.1"
     html-tokenize "^2.0.0"
     multipipe "^1.0.2"
     through "^2.3.8"
-
-create-emotion@^10.0.9:
-  version "10.0.9"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.9.tgz#290c2036126171c9566fa24f49c9241d54625138"
-  dependencies:
-    "@emotion/cache" "^10.0.9"
-    "@emotion/serialize" "^0.11.6"
-    "@emotion/sheet" "0.9.2"
-    "@emotion/utils" "0.11.1"
 
 create-emotion@^9.2.12:
   version "9.2.12"
@@ -4938,11 +4928,11 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-emotion-server@^10.0.7:
-  version "10.0.9"
-  resolved "https://registry.yarnpkg.com/emotion-server/-/emotion-server-10.0.9.tgz#494a94bd5c7a64d517f1e116d27c830d060f6b0e"
+emotion-server@9:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion-server/-/emotion-server-9.2.12.tgz#aaaaa04843108943d1ce5a796e0bc40b06a3223e"
   dependencies:
-    create-emotion-server "10.0.0"
+    create-emotion-server "^9.2.12"
 
 emotion-theming@^10.0.7:
   version "10.0.10"
@@ -4952,14 +4942,7 @@ emotion-theming@^10.0.7:
     hoist-non-react-statics "^3.3.0"
     object-assign "^4.1.1"
 
-emotion@^10.0.7:
-  version "10.0.9"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.9.tgz#2c37598af13df31dcd35a1957eaa8830f368c066"
-  dependencies:
-    babel-plugin-emotion "^10.0.9"
-    create-emotion "^10.0.9"
-
-emotion@^9.1.2:
+emotion@9, emotion@^9.1.2:
   version "9.2.12"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
   dependencies:


### PR DESCRIPTION
react-select uses emotion@9 and we need the same version installed
locally to make the SSR version work properly.

Additionally added styles for the noscript provided by gatsby.