### PR TITLE
Fix storybook for navbar and header

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -15,7 +15,7 @@ export default class Header extends React.Component {
   }
 
   render () {
-    const { fullVersion, subsection, isSingleRecipe } = this.props
+    const { fullVersion, subsection, isSingleRecipe, categories } = this.props
     const { alreadyMounted } = this.state
 
     const headerStyles = isSingleRecipe
@@ -25,7 +25,7 @@ export default class Header extends React.Component {
     return (
       <header className={headerStyles}>
         <div className={styles.navbar}>
-          <Navbar hasHomepageLink={fullVersion === false}/>
+          <Navbar categories={categories} hasHomepageLink={fullVersion === false}/>
         </div>
 
         {

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,18 +1,32 @@
 import React from 'react'
 import Header from '../header'
 import Footer from '../footer'
+import SiteCategories from '../site_categories'
 
 import './layout.sass'
 
-export default function Layout({children, fullHeaderVersion, subsection, isSingleRecipe}) {
-  return <div>
+const HeaderWithCategories = ({fullVersion, subsection, isSingleRecipe}) => (
+  <SiteCategories render={categories =>
     <Header
-      fullVersion={fullHeaderVersion}
+      categories={categories}
+      fullVersion={fullVersion}
       subsection={subsection}
       isSingleRecipe={isSingleRecipe}
     />
+  }/>
+)
 
-    {children}
-    <Footer />
-  </div>
+export default function Layout({children, fullHeaderVersion, subsection, isSingleRecipe}) {
+  return (
+    <div>
+      <HeaderWithCategories
+        fullVersion={fullHeaderVersion}
+        subsection={subsection}
+        isSingleRecipe={isSingleRecipe}
+      />
+
+      {children}
+      <Footer />
+    </div>
+  )
 }

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -9,7 +9,7 @@ function titleize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-class Navbar extends React.Component {
+export default class Navbar extends React.Component {
   constructor(props) {
     super(props)
 
@@ -53,7 +53,7 @@ class Navbar extends React.Component {
         <div className={styles.navbar_menu_overlay} onClick={this.handleMenuCloseClick} />)
       : null;
 
-    const {hasHomepageLink} = this.props
+    const {hasHomepageLink, categories} = this.props
 
     return (
       <nav className={styles.navbar}>
@@ -84,35 +84,19 @@ class Navbar extends React.Component {
               <Logo/>
             </Link>
           }
-          <StaticQuery query={graphql`
-          query LoadCategories {
-            allRecipeCategory (sort: { fields: [position] }) {
-              edges {
-                node {
-                  name
-                  slug
-                }
-              }
-            }
-          }
-        `}
-         render={data => (
-           data.allRecipeCategory.edges
-             .map(({node: {slug, name}}) => (
-               <Link
-                 to={`/${slug}`}
-                 key={slug}
-                 className={styles.navbar_link}
-                 onClick={this.handleMenuCloseClick}
-               >
-               {titleize(name)}
-             </Link>
-           ))
-         )} />
+
+          {categories.map(({slug, name}) =>
+           <Link
+               to={`/${slug}`}
+               key={slug}
+               className={styles.navbar_link}
+               onClick={this.handleMenuCloseClick}
+             >
+             {titleize(name)}
+           </Link>
+          )}
         </div>
     </nav>
     )
   }
 }
-
-export default Navbar

--- a/src/components/site_categories/index.js
+++ b/src/components/site_categories/index.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { StaticQuery, graphql } from 'gatsby'
+
+export default function SiteCategories({render}) {
+  return <StaticQuery query={graphql`
+    query LoadCategories {
+      allRecipeCategory (sort: { fields: [position] }) {
+        edges {
+          node {
+            name
+            slug
+          }
+        }
+      }
+    }
+  `} render={data => render(data.allRecipeCategory.edges.map(({node}) => node))}
+  />
+}

--- a/src/stories/header.stories.js
+++ b/src/stories/header.stories.js
@@ -3,13 +3,18 @@ import { storiesOf } from '@storybook/react'
 
 import Header from '../components/header'
 
+const categories = [
+  {name: 'Category1', slug: 'category1'},
+  {name: 'Category2', slug: 'category2'}
+]
+
 storiesOf('Header', module)
   .add('full header', () => (
-    <Header fullVersion={true} />
+    <Header categories={categories} fullVersion={true} />
   ))
   .add('header on subsection', () => (
-    <Header fullVersion={false} subsection='obiady' />
+    <Header categories={categories} fullVersion={false} subsection='obiady' />
   ))
   .add('header on a recipe page', () => (
-    <Header fullVersion={false} isSingleRecipe={true} />
+    <Header categories={categories} fullVersion={false} isSingleRecipe={true} />
   ))

--- a/src/stories/navbar.stories.js
+++ b/src/stories/navbar.stories.js
@@ -3,7 +3,19 @@ import { storiesOf } from '@storybook/react'
 
 import Navbar from '../components/navbar'
 
+const categories = [
+  {name: 'Category1', slug: 'category1'},
+  {name: 'Category2', slug: 'category2'},
+  {name: 'Category3', slug: 'category3'}
+]
+
+const BackgroundDecorator = storyFn => <div style={{backgroundColor: '#e98500'}}>{storyFn()}</div>;
+
 storiesOf('Navbar', module)
+  .addDecorator(BackgroundDecorator)
   .add('default', () => (
-    <Navbar />
+    <Navbar categories={categories} />
+  ))
+  .add('with homepage link', () => (
+    <Navbar categories={categories} hasHomepageLink={true}/>
   ))


### PR DESCRIPTION
Instead of mocking static query as described in #129 we have data loaded by static query separated from the components in storybook.