### PR TITLE
Use a larger image for the lightbox content

### DIFF
--- a/src/components/gallery/index.js
+++ b/src/components/gallery/index.js
@@ -40,7 +40,7 @@ export default class Gallery extends Component {
           })
         }} key={ndx}>
           <Img
-            fluid={img.childImageSharp.fluid}
+            fluid={img.childImageSharp.small}
             alt={'Picture of the dish'}
             className={styles.gallery_image}
             key={ndx}
@@ -49,7 +49,7 @@ export default class Gallery extends Component {
       )
     })
 
-    const imgSources = images.map(img => img.childImageSharp.fluid.src)
+    const imgSources = images.map(img => img.childImageSharp.large.src)
 
     return (
       <div className={styles.gallery_container}>

--- a/src/templates/post-page/index.js
+++ b/src/templates/post-page/index.js
@@ -109,7 +109,10 @@ export const pageQuery = graphql`
       }
       gallery {
         childImageSharp {
-          fluid(maxWidth: 500, traceSVG: { color: "#e98500" }) {
+          small: fluid(maxWidth: 500, traceSVG: { color: "#e98500" }) {
+            ...GatsbyImageSharpFluid_tracedSVG
+          }
+          large: fluid(maxWidth: 5000, traceSVG: { color: "#e98500" }) {
             ...GatsbyImageSharpFluid_tracedSVG
           }
         }


### PR DESCRIPTION
Fixes: https://github.com/ertrzyiks/yummy/issues/184

The resulting image isn't large enough for the 4x zoom, but 1-3 look quite acceptable.
There is no option to reduce the zoomability, we either have it or disable it entirely in the lightbox.